### PR TITLE
feat: write to stdout on ConnectionError

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -10,7 +10,7 @@ config = configparser.ConfigParser()
 
 # File must be opened with utf-8 explicitly
 with open(expanduser('~/.config/polybar/crypto-config'), 'r', encoding='utf-8') as f:
-	config.read_file(f)
+    config.read_file(f)
 
 # Everything except the general section
 currencies = [x for x in config.sections() if x != 'general']
@@ -19,16 +19,20 @@ params = {'convert': base_currency}
 
 
 for currency in currencies:
-	icon = config[currency]['icon']
-	json = requests.get(f'https://api.coingecko.com/api/v3/coins/{currency}',
-					 	).json()["market_data"]
-	local_price = round(Decimal(json["current_price"][f'{base_currency.lower()}']), 2)
-	change_24 = float(json['price_change_percentage_24h'])
+    try:
+        icon = config[currency]['icon']
+        json = requests.get(f'https://api.coingecko.com/api/v3/coins/{currency}').json()["market_data"]
+        local_price = round(Decimal(json["current_price"][f'{base_currency.lower()}']), 2)
+        change_24 = float(json['price_change_percentage_24h'])
 
-	display_opt = config['general']['display']
-	if display_opt == 'both' or display_opt == None:
-		sys.stdout.write(f'{icon} {local_price}/{change_24:+}%  ')
-	elif display_opt == 'percentage':
-		sys.stdout.write(f'{icon} {change_24:+}%  ')
-	elif display_opt == 'price':
-		sys.stdout.write(f'{icon} {local_price}  ')
+        display_opt = config['general']['display']
+        if display_opt == 'both' or display_opt == None:
+            sys.stdout.write(f'{icon} {local_price}/{change_24:+}%  ')
+        elif display_opt == 'percentage':
+            sys.stdout.write(f'{icon} {change_24:+}%  ')
+        elif display_opt == 'price':
+            sys.stdout.write(f'{icon} {local_price}  ')
+    except requests.exceptions.ConnectionError as e:
+        sys.stdout.write('not connected')
+        break
+


### PR DESCRIPTION
First of all, thanks for the script!

Whenever I'm on a bad connection which results in failure to hit the API, the script will write some ugly Traceback err string to the bar.
![traceback](https://user-images.githubusercontent.com/54321501/151938941-d3ef15ad-a719-4760-83ec-5e327a3ea8b1.png)

In this PR I add a simple `try except` that writes `not connected` instead (inspired by [`polybar`'s default value for `label-disconnected`](https://github.com/polybar/polybar/wiki/Module:-network)) whenever the script fails to hit the API.
![not connected](https://user-images.githubusercontent.com/54321501/151939310-e3eba010-2e32-410b-8a78-daddf667cad6.png)
