### PR TITLE
Spaces appended to end of price or percentage make padding uneven

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -27,11 +27,13 @@ for currency in currencies:
 
         display_opt = config['general']['display']
         if display_opt == 'both' or display_opt == None:
-            sys.stdout.write(f'{icon} {local_price}/{change_24:+}%  ')
+            sys.stdout.write(f'{icon} {local_price}/{change_24:+}%')
         elif display_opt == 'percentage':
-            sys.stdout.write(f'{icon} {change_24:+}%  ')
+            sys.stdout.write(f'{icon} {change_24:+}%')
         elif display_opt == 'price':
-            sys.stdout.write(f'{icon} {local_price}  ')
+            sys.stdout.write(f'{icon} {local_price}')
+        if currency != currencies[-1]:
+            sys.stdout.write('  ')
     except requests.exceptions.ConnectionError as e:
         sys.stdout.write('not connected')
         break


### PR DESCRIPTION
The for loop will generate spaces after every crypto's price or percentage. This is a problem when there is no padding generated before the ticker as well as there is overflow padding on the right side of the module.

Implemented a statement to check if the crypto is the last item in the list, if so, don't add a space.

Before:
![1644003851](https://user-images.githubusercontent.com/44419333/152593357-3881b0ee-4bf5-4d66-86a5-82f676425be5.png)

After:
![1644003822](https://user-images.githubusercontent.com/44419333/152593324-b7060526-f6c7-4a2e-9629-866b7a6732e1.png)

